### PR TITLE
add vimwiki option as standard init.lua

### DIFF
--- a/lua/cmp_zotcite/init.lua
+++ b/lua/cmp_zotcite/init.lua
@@ -2,7 +2,7 @@ local cmp = require'cmp'
 
 local source = { }
 
-local options = { filetypes = {'markdown', 'rmd', 'quarto'}}
+local options = { filetypes = {'markdown', 'rmd', 'quarto', 'vimwiki'}}
 
 source.new = function()
     local self = setmetatable({}, { __index = source })


### PR DESCRIPTION
Hi jalvesaq, 

Following the pull request for https://github.com/jalvesaq/zotcite 

Here the same applies. For the default it is possible to add 'vimwiki' as a standard syntax for the plugin. This reduces the configuration needed for `nvim-cmp` Of Course, it is possible to run the `zotcite` without this plugin using omni-completion, however having the auto-complete via `nvim-cmp` may allow quicker completion particularly for citing many sources. 

I hope this okay.

Best wishes and thanks for an easy implementation of Zotero in nvim. 